### PR TITLE
Traces array abstraction

### DIFF
--- a/src/pt/process_samples.jl
+++ b/src/pt/process_samples.jl
@@ -1,39 +1,79 @@
 
 """
-$SIGNATURES 
+    $(TYPEDEF)
+
+Array convience wrapper for [`traces`](@ref) reduced recorder. We require a [`PT`](@ref)
+object, and the `chain` number which specifies the chain index (has to be a target chain)
+you wish to extract.
+
+This should not be called directly and the user should instead look at [`get_sample`](@ref).
+"""
+struct SampleArray{T,PT} <: AbstractVector{T}
+    pt::PT
+    chain::Int
+    function SampleArray(pt::P, chain::Int) where {P<:PT}
+        rr = pt.reduced_recorders
+        T = typeof(get_sample(pt, chain, 1))
+        @assert (:traces ∈ propertynames(rr)) "trace recorder not found, did you include it in your run?"
+        return new{T,PT}(pt, chain)
+    end
+end
+
+Base.size(s::SampleArray) = (length(s.pt.reduced_recorders.traces),)
+Base.IndexStyle(::Type{<:SampleArray}) = IndexLinear()
+Base.getindex(s::SampleArray, i::Int) = get_sample(s.pt, s.chain, i)
+Base.setindex!(::SampleArray, i::Int) = error("You can not set the elements of SampleArray")
+
+"""
+$(SIGNATURES)
+"""
+get_sample(pt::PT, chain::Int) = SampleArray(pt, chain)
+
+
+
+function Base.show(io::IO, s::SampleArray{T,PT}) where {T,PT}
+    println(io, "SampleArray{$T}")
+    println(io, "\ttarget chain id:   $(s.chain)")
+    println(io, "\tnumber of samples: $(length(s))")
+end
+
+
+"""
+$SIGNATURES
 """
 get_sample(pt::PT, chain::Int, scan::Int) = pt.reduced_recorders.traces[chain => scan]
 
-""" 
+"""
 $SIGNATURES
 """
-process_samples(processor::Function, pt::PT, round::Int = latest_checkpoint_folder(pt.exec_folder)) = 
-    process_samples(processor, pt.exec_folder, round) 
+process_samples(processor::Function, pt::PT, round::Int = latest_checkpoint_folder(pt.exec_folder)) =
+    process_samples(processor, pt.exec_folder, round)
 
-""" 
+"""
 $SIGNATURES
 """
-process_samples(processor::Function, pt::Result{PT}, round::Int = latest_checkpoint_folder(pt.exec_folder)) = 
-    process_samples(processor, pt.exec_folder, round) 
+process_samples(processor::Function, pt::Result{PT}, round::Int = latest_checkpoint_folder(pt.exec_folder)) =
+    process_samples(processor, pt.exec_folder, round)
 
-""" 
-$SIGNATURES 
 
-Process samples that were saved to disk using the `disk` recorder, at the 
-given `round`. 
+"""
+$SIGNATURES
 
-Each sample is passed to the `processor` function, by calling 
-`processor(chain_index, scan_index, sample)` where 
+Process samples that were saved to disk using the `disk` recorder, at the
+given `round`.
+
+Each sample is passed to the `processor` function, by calling
+`processor(chain_index, scan_index, sample)` where
 `chain_index` is the index of the target chain (in classical parallel tempering,
-there is only one chain at target temperature, so in that case it can be ignored, 
-but it will be non-trivial in e.g. stabilized variational parallel tempering), 
-`scan_index` is the iteration index 
-within the round, starting at 1, and sample is the deserialized sample. 
+there is only one chain at target temperature, so in that case it can be ignored,
+but it will be non-trivial in e.g. stabilized variational parallel tempering),
+`scan_index` is the iteration index
+within the round, starting at 1, and sample is the deserialized sample.
 
-This iterates over the samples in increasing order, looping over `chain_index` in the 
-outer loop and `scan_index` in the inner loop. 
+This iterates over the samples in increasing order, looping over `chain_index` in the
+outer loop and `scan_index` in the inner loop.
 """
-function process_samples(processor::Function, exec_folder::String, round::Int) 
+function process_samples(processor::Function, exec_folder::String, round::Int)
     if round == 0
         error("no checkpoint is available yet for $exec_folder")
     elseif round < 0
@@ -42,10 +82,10 @@ function process_samples(processor::Function, exec_folder::String, round::Int)
 
     deserialize_immutables!("$exec_folder/immutables.jls")
     samples_dir = "$exec_folder/round=$round/samples"
-    # open readers 
+    # open readers
     readers = Dict{String, ZipFile.Reader}()
     for file in readdir(samples_dir)
-        if startswith(file, "replica=") 
+        if startswith(file, "replica=")
             readers[file] = ZipFile.Reader("$samples_dir/$file")
         end
     end
@@ -56,7 +96,7 @@ function process_samples(processor::Function, exec_folder::String, round::Int)
     n_scans = 0
     target_chains_set = Set{Int}()
     for reader in values(readers)
-        for zip_internal_file in reader.files 
+        for zip_internal_file in reader.files
             code = Base.split(zip_internal_file.name, '_')
             chain = parse(Int, code[1])
             scan = parse(Int, code[2])
@@ -72,10 +112,10 @@ function process_samples(processor::Function, exec_folder::String, round::Int)
     sort!(chains)
 
     for chain in chains
-        for scan in 1:n_scans 
+        for scan in 1:n_scans
             key = chain => scan
-            zip_internal_file = samples_layout[key] 
-            sample = deserialize(zip_internal_file) 
+            zip_internal_file = samples_layout[key]
+            sample = deserialize(zip_internal_file)
             processor(chain, scan, sample)
         end
     end

--- a/src/pt/process_samples.jl
+++ b/src/pt/process_samples.jl
@@ -22,7 +22,7 @@ end
 Base.size(s::SampleArray) = (length(s.pt.reduced_recorders.traces),)
 Base.IndexStyle(::Type{<:SampleArray}) = IndexLinear()
 Base.getindex(s::SampleArray, i::Int) = get_sample(s.pt, s.chain, i)
-Base.setindex!(::SampleArray, i::Int) = error("You can not set the elements of SampleArray")
+Base.setindex!(::SampleArray, v, i::Int) = error("You cannot set the elements of SampleArray")
 
 """
 $(SIGNATURES)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -112,9 +112,9 @@ end
     s = get_sample(pt, 10)
     @test marginal == first.(s)
     @test abs(mean(marginal) - 0.0) < 0.05
-    @test mean(marginal) == mean(s)[1]
-    @test s[1] = get_sample(pt, 10, 1)
-    @test size(s)[1] = length(marginal)
+    @test mean(marginal) ≈ mean(s)[1]
+    @test s[1] == get_sample(pt, 10, 1)
+    @test size(s)[1] == length(marginal)
     @test_throws "You cannot" setindex!(ss, ss[2], 1)
     # check that the disk serialization gives the same result
     process_samples(pt) do chain, scan, sample

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,7 +115,7 @@ end
     @test mean(marginal) == mean(s)[1]
     @test s[1] = get_sample(pt, 10, 1)
     @test size(s)[1] = length(marginal)
-    @test "You cannot" setindex!(ss, ss[2], 1)
+    @test_throws "You cannot" setindex!(ss, ss[2], 1)
     # check that the disk serialization gives the same result
     process_samples(pt) do chain, scan, sample
         @test sample == get_sample(pt, chain, scan)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,7 +115,7 @@ end
     @test mean(marginal) ≈ mean(s)[1]
     @test s[1] == get_sample(pt, 10, 1)
     @test size(s)[1] == length(marginal)
-    @test_throws "You cannot" setindex!(ss, ss[2], 1)
+    @test_throws "You cannot" setindex!(s, s[2], 1)
     # check that the disk serialization gives the same result
     process_samples(pt) do chain, scan, sample
         @test sample == get_sample(pt, chain, scan)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,7 +24,7 @@ include("vector.jl")
 
 function test_load_balance(n_processes, n_tasks)
     for p in 1:n_processes
-        lb = LoadBalance(p, n_processes, n_tasks)        
+        lb = LoadBalance(p, n_processes, n_tasks)
         globals = my_global_indices(lb)
         @assert length(globals) == my_load(lb)
         for g in globals
@@ -37,42 +37,42 @@ end
     n_mpis = set_n_mpis_to_one_on_windows(4)
     recorder_builders = [swap_acceptance_pr, index_process, log_sum_ratio, round_trip, energy_ac1]
 
-    # test swapper 
+    # test swapper
     pigeons(
-        target = toy_mvn_target(1), 
+        target = toy_mvn_target(1),
         n_rounds = 10,
-        checked_round = 3, 
+        checked_round = 3,
         recorder_builders = recorder_builders,
-        checkpoint = true, 
+        checkpoint = true,
         on = ChildProcess(
                 n_local_mpi_processes = n_mpis,
                 n_threads = 2,
-                mpiexec_args = extra_mpi_args())) 
+                mpiexec_args = extra_mpi_args()))
 
     # Turing:
     pigeons(
-        target = TuringLogPotential(flip_model_unidentifiable()), 
+        target = TuringLogPotential(flip_model_unidentifiable()),
         n_rounds = 10,
-        checked_round = 3, 
+        checked_round = 3,
         multithreaded = true,
         recorder_builders = recorder_builders,
-        checkpoint = true, 
+        checkpoint = true,
         on = ChildProcess(
                 dependencies = [Distributions, DynamicPPL, LinearAlgebra, "turing.jl"],
                 n_local_mpi_processes = n_mpis,
                 n_threads = 2,
                 mpiexec_args = extra_mpi_args()))
-    
+
     # Blang:
     if !Sys.iswindows() # JNI crashes on windows; see commit right after c016f59c84645346692f720854b7531743c728bf
         Pigeons.setup_blang("blangDemos")
-        pigeons(; 
-            target = Pigeons.blang_ising(), 
+        pigeons(;
+            target = Pigeons.blang_ising(),
             n_rounds = 10,
-            checked_round = 3, 
-            recorder_builders = recorder_builders, 
-            multithreaded = true, 
-            checkpoint = true, 
+            checked_round = 3,
+            recorder_builders = recorder_builders,
+            multithreaded = true,
+            checkpoint = true,
             on = ChildProcess(
                     n_local_mpi_processes = n_mpis,
                     n_threads = 2,
@@ -95,7 +95,7 @@ end
     log_potential(x) =  -x[1]^3 - 2.4 * x[1]^2
     dim = 1
     n_leaps = 3
-    v = [randn(rng)] 
+    v = [randn(rng)]
     x = [randn(rng)]
     start = copy(x)
     momentum_log_potential = Pigeons.ScaledPrecisionNormalLogPotential(1.0, dim)
@@ -106,13 +106,14 @@ end
 end
 
 @testset "Traces" begin
-    pt = pigeons(target = toy_mvn_target(10), recorder_builders = [traces, disk], checkpoint = true) 
-    @test length(pt.reduced_recorders.traces) == 1024 
+    pt = pigeons(target = toy_mvn_target(10), recorder_builders = [traces, disk], checkpoint = true)
+    @test length(pt.reduced_recorders.traces) == 1024
     marginal = [get_sample(pt, 10, i)[1] for i in 1:1024]
-    @test abs(mean(marginal) - 0.0) < 0.05 
+    @test marginal == first.(get_sample(pt, 10))
+    @test abs(mean(marginal) - 0.0) < 0.05
 
     # check that the disk serialization gives the same result
-    process_samples(pt) do chain, scan, sample 
+    process_samples(pt) do chain, scan, sample
         @test sample == get_sample(pt, chain, scan)
     end
 end
@@ -154,9 +155,9 @@ end
 @testset "Round trips" begin
     n_chains = 4
     n_rounds = 5
-    
+
     pt = pigeons(; target = Pigeons.TestSwapper(1.0), recorder_builders = [Pigeons.round_trip], n_chains, n_rounds);
-    
+
     len = 2^(n_rounds)
     truth = 0.0
     for i in 0:(n_chains-1)
@@ -173,9 +174,9 @@ end
         for i in eachindex(m)
             @test abs(m[i] - 0.0) < 0.001
         end
-        v = var(pt, var_name) 
-        for i in eachindex(v) 
-            @test abs(v[i] - 0.1) < 0.001 
+        v = var(pt, var_name)
+        for i in eachindex(v)
+            @test abs(v[i] - 0.1) < 0.001
         end
     end
 end
@@ -185,17 +186,17 @@ end
     n_mpis = set_n_mpis_to_one_on_windows(4)
     recorder_builders = []
     pigeons(
-        target = Pigeons.TestSwapper(0.5), 
+        target = Pigeons.TestSwapper(0.5),
         n_rounds = 14,
-        checked_round = 12, 
+        checked_round = 12,
         n_chains = 200,
         multithreaded = false,
         recorder_builders = recorder_builders,
-        checkpoint = true, 
+        checkpoint = true,
         on = ChildProcess(
                 n_local_mpi_processes = n_mpis,
                 n_threads = 2,
-                mpiexec_args = extra_mpi_args())) 
+                mpiexec_args = extra_mpi_args()))
 end
 
 @testset "Entanglement" begin
@@ -223,7 +224,7 @@ end
 
 @testset "LogSum" begin
     m = Pigeons.LogSum()
-    
+
     fit!(m, 2.1)
     fit!(m, 4)
     v1 = value(m)
@@ -232,7 +233,7 @@ end
 
     fit!(m, 2.1)
     fit!(m, 4)
-    m2 = Pigeons.LogSum() 
+    m2 = Pigeons.LogSum()
     fit!(m2, 50.1)
     combined = merge(m, m2)
     @assert value(combined) ≈ log(exp(v1) + exp(50.1))
@@ -271,5 +272,3 @@ end
 @testset "SliceSampler" begin
     test_slice_sampler()
 end
-
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,9 +109,13 @@ end
     pt = pigeons(target = toy_mvn_target(10), recorder_builders = [traces, disk], checkpoint = true)
     @test length(pt.reduced_recorders.traces) == 1024
     marginal = [get_sample(pt, 10, i)[1] for i in 1:1024]
-    @test marginal == first.(get_sample(pt, 10))
+    s = get_sample(pt, 10)
+    @test marginal == first.(s)
     @test abs(mean(marginal) - 0.0) < 0.05
-
+    @test mean(marginal) == mean(s)[1]
+    @test s[1] = get_sample(pt, 10, 1)
+    @test size(s)[1] = length(marginal)
+    @test "You cannot" setindex!(ss, ss[2], 1)
     # check that the disk serialization gives the same result
     process_samples(pt) do chain, scan, sample
         @test sample == get_sample(pt, chain, scan)


### PR DESCRIPTION
This pull request will try to add a layer of abstraction to Pigeons trace or `get_sample` interface. 

The current implementation just creates a `SampleArray` type that implements the minimal Julia abstract array interface so we can easiliy compute e.g., means.

Currently the interface only works with the trace recorder but maybe we want to generalize to disk recorders as well? Additionally, I require the pt object and the chain to create this. Maybe we also want to leave out the chain index. In that case we would form a matrix  like object where the two indices correspond to the sample index and the chain index. 

For example suppose the target chain indices are [10, 20] if you run a 2 leg PT with output `pt`. The current interface would then look like

```julia
s1 = get_sample(pt, 10)
s2 = get_sample(pt, 20)
# access an element
s1[1]

# compute some means
mean(s1)
mean(s2)
```

The second interface would instead look something like
```julia
s = get_sample(pt)

# Now get the samples for the first chain
s1 = s[:,1]
# and now for the second chain
s2 = s[:,2]

# compute the means for both chains
mean(s)
# compute the means for each chain separately
mean(s, dims=1)

# print out the key map from array index to chain index
keymap(s)
(1=>10, 2=>20)
```
