### PR TITLE
import DynamicPPL to use `toy_turing_unid_target`

### DIFF
--- a/docs/src/output-extended.md
+++ b/docs/src/output-extended.md
@@ -19,16 +19,17 @@ various common scenarios below.
 
 ## Posterior densities and trace plots for all chains
 
-Make sure to have the third party `MCMCChains` and `StatsPlots`
+Make sure to have the third party `DynamicPPL`, `MCMCChains`, and `StatsPlots`
 packages installed via 
 
 ```
-using Pkg; Pkg.add("MCMCChains", "StatsPlots")
+using Pkg; Pkg.add("DynamicPPL", "MCMCChains", "StatsPlots")
 ```
 
 Then use the following:
 
-```@example 
+```@example
+using DynamicPPL
 using Pigeons
 using MCMCChains
 using StatsPlots

--- a/docs/src/output-normalization.md
+++ b/docs/src/output-normalization.md
@@ -25,6 +25,7 @@ As a side-product of parallel tempering, we automatically obtain an approximatio
 It is shown in the [standard output report](@ref output-reports) produced at each round:
 
 ```@example constants
+using DynamicPPL
 using Pigeons
 
 # example target: Binomial likelihood with parameter p = p1 * p2

--- a/docs/src/output-numerical.md
+++ b/docs/src/output-numerical.md
@@ -14,15 +14,16 @@ We outline some useful features here, read
 
 ## Quick summary of ESS, moments, etc
 
-Make sure to have the third party package `MCMCChains`  installed via 
+Make sure to have the third party packages `DynamicPPL` and `MCMCChains` installed via 
 
 ```
-using Pkg; Pkg.add("MCMCChains")
+using Pkg; Pkg.add("DynamicPPL", "MCMCChains")
 ```
 
 Also make sure to record the trace, with `record = [traces]`:
 
 ```@example numerical
+using DynamicPPL
 using Pigeons
 using MCMCChains
 

--- a/docs/src/output-online.md
+++ b/docs/src/output-online.md
@@ -21,6 +21,7 @@ Simply include the [`online()`](@ref) recorder to get
 access to constant memory computation of the mean and variance.  
 
 ```@example online
+using DynamicPPL
 using Pigeons
 
 # example target: Binomial likelihood with parameter p = p1 * p2

--- a/docs/src/output-plotting.md
+++ b/docs/src/output-plotting.md
@@ -15,16 +15,17 @@ See below for examples of posterior densities and trace plots.
 
 ## Posterior densities and trace plots
 
-Make sure to have the third party `MCMCChains` and `StatsPlots`
-packages installed via 
+Make sure to have the third party `DynamicPPL`, `MCMCChains`, and `StatsPlots`
+packages installed via
 
 ```
-using Pkg; Pkg.add("MCMCChains", "StatsPlots")
+using Pkg; Pkg.add("DynamicPPL", "MCMCChains", "StatsPlots")
 ```
 
 Then use the following:
 
 ```@example traces
+using DynamicPPL
 using Pigeons
 using MCMCChains
 using StatsPlots
@@ -90,14 +91,15 @@ nothing # hide
     The code snippet in this section only works with Julia 1.9. 
     See https://sefffal.github.io/PairPlots.jl/dev/chains/ for a workaround.
 
-Make sure to have the third party packages `MCMCChains`, `CairoMakie` and `PairPlots`
+Make sure to have the third party packages `DynamicPPL`, `MCMCChains`, `CairoMakie`, and `PairPlots`
 installed via 
 
 ```
-using Pkg; Pkg.add("MCMCChains", "CairoMakie", "PairPlots")
+using Pkg; Pkg.add("DynamicPPL", "MCMCChains", "CairoMakie", "PairPlots")
 ```
 
 ```
+using DynamicPPL
 using Pigeons
 using MCMCChains
 using CairoMakie

--- a/docs/src/output-pt.md
+++ b/docs/src/output-pt.md
@@ -21,6 +21,7 @@ at each round and can also be accessed via
 [`global_barrier()`](@ref).
 
 ```@example pt
+using DynamicPPL
 using Pigeons
 
 pt = pigeons(target = Pigeons.toy_turing_unid_target(100, 50))
@@ -32,6 +33,7 @@ labelled Λ and Λ_var for the fixed and variational global barriers
 respectively:
 
 ```@example pt
+using DynamicPPL
 using Pigeons
 
 pt = pigeons(target = Pigeons.toy_turing_unid_target(100, 50), 

--- a/docs/src/output-traces.md
+++ b/docs/src/output-traces.md
@@ -12,7 +12,8 @@ a Monte Carlo average of the form ``\sum_i f(X_i) / n``.
 To indicate that the traces should be saved, use
 
 ```@example record-traces
-using Pigeons 
+using DynamicPPL
+using Pigeons
 
 target = Pigeons.toy_turing_unid_target(100, 50)
 

--- a/docs/src/unidentifiable-example.md
+++ b/docs/src/unidentifiable-example.md
@@ -29,6 +29,7 @@ so that setting the number of chains to one reduces to a
 standard MCMC algorithm. 
 
 ```@example why
+using DynamicPPL
 using Pigeons
 using MCMCChains
 using StatsPlots

--- a/docs/src/variational.md
+++ b/docs/src/variational.md
@@ -17,6 +17,7 @@ Enable variational PT by supplier the `variational` option
 to `pigeons(...)`:
 
 ```@example variational
+using DynamicPPL
 using Pigeons
 
 pigeons(


### PR DESCRIPTION
The `toy_turing_unid_target`, used in several places in the documentation, is defined in the `PigeonsDynamicPPLExt` package extension, which requires `DynamicPPL` to be installed and imported. However, the documentation does not indicate this, which can be confusing for anyone who hasn't worked with Julia package extensions before.

This PR augments the existing documentation by indicating to the user that the `DynamicPPL` package should be installed and imported whenever the ``toy_turing_unid_target` is used.

For consistency with the existing documentation, the installation instructions are only augmented when they are present (I think there were some places in the docs that don't indicate any third-party requirements, even though a requirement such as `MCMCChains` may have been needed); and the imports are only augmented when all required imports are already present (some places in the docs don't indicate the required imports, presumably because they are implied earlier on in the same documentation page). However, I'm happy to augment the docs in these places as well, if desired.

Thanks for this great tool and let me know if there's anything I should change in this PR!