### PR TITLE
warning for DistributionLogPotential+Stan and fix test

### DIFF
--- a/ext/PigeonsBridgeStanExt/interface.jl
+++ b/ext/PigeonsBridgeStanExt/interface.jl
@@ -87,6 +87,15 @@ Pigeons.default_reference(target::StanLogPotential) = target
 #=
 DistributionLogPotential interface
 =#
+
+"""
+Evaluate a `DistributionLogPotential` on a `StanState`.
+
+!!! warning
+
+    The distribution enclosed by the log potential must be defined on the 
+    **unconstrained space**.
+"""
 (ref::Pigeons.DistributionLogPotential)(state::Pigeons.StanState) = 
     ref(state.unconstrained_parameters)
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 AdvancedHMC = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
 ArgMacros = "dbc42088-9de8-42a0-8ec8-2cd114e1ea3e"
+Bijectors = "76274a88-744f-5084-9051-94815aaf08c4"
 BridgeStan = "c88b6f0a-829e-4b0b-94b7-f06ab5908f5a"
 Comrade = "99d987ce-9a1e-4df8-bc0b-1ea019aa547b"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"


### PR DESCRIPTION
Adds a warning to the docs to remind the user that evaluating a `DistributionLogPotential` on a `StanState` assumes that the enclosed `Distribution` is defined on the unconstrained space. Also fixes a test that made this mistake.