### PR TITLE
remove arch argument in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -98,7 +98,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.9'
+          - '1'
         os:
           - macos-latest
         mpi:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
   
   # test using MPICH as MPI backend (default in MPI.jl)
   test-MPICH-jll:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -29,8 +29,6 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        arch:
-          - x64
     steps:
       - name: Enable long paths on windows
         if: ${{ startsWith(matrix.os, 'windows') }}
@@ -44,7 +42,6 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
@@ -65,8 +62,6 @@ jobs:
           - '1.9'
         os:
           - ubuntu-latest
-        arch:
-          - x64
 
       fail-fast: false
     env:
@@ -79,7 +74,6 @@ jobs:
     - uses: julia-actions/setup-julia@latest
       with:
         version: ${{ matrix.version }}
-        arch: ${{ matrix.arch }}
     - uses: julia-actions/cache@v1
 
     - name: use OpenMPI_jll
@@ -129,7 +123,6 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
-          arch: x64
 
       - uses: julia-actions/cache@v1
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.version }}
       - uses: julia-actions/cache@v1
@@ -120,7 +120,7 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.version }}
 
@@ -150,7 +150,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@latest
         with:
           version: '1.9'
       - uses: julia-actions/julia-buildpkg@v1


### PR DESCRIPTION
Let [`setup-julia`](https://github.com/julia-actions/setup-julia?tab=readme-ov-file#inputs) action use the native arch of the runner. Addresses #227 .