### PR TITLE
use macos-12 on brew MPI tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -100,7 +100,7 @@ jobs:
         version:
           - '1'
         os:
-          - macos-latest
+          - macos-12 # temporary fix for https://github.com/JuliaParallel/MPI.jl/issues/828
         mpi:
           - mpich
           - openmpi


### PR DESCRIPTION
See #229 and https://github.com/JuliaParallel/MPI.jl/issues/828