### PR TITLE
Add `reversibility_rate` to report

### DIFF
--- a/src/pt/report.jl
+++ b/src/pt/report.jl
@@ -21,6 +21,8 @@ all_reports() = [
         "  mean|ρ| "   => pt -> mean(abs.(energy_ac1s(pt, true))),
         "  min(αₑ) "   => pt -> minimum(explorer_mh_prs(pt)), 
         " mean(αₑ) "   => pt -> mean(explorer_mh_prs(pt)),
+        " min(RR)  "   => pt -> minimum(Pigeons.recorder_values(pt, :reversibility_rate)), 
+        " mean(RR) "   => pt -> mean(Pigeons.recorder_values(pt, :reversibility_rate)),
     ]
 
 """

--- a/src/recorders/recorder.jl
+++ b/src/recorders/recorder.jl
@@ -45,10 +45,13 @@ end
 """ 
 $SIGNATURES
 
-Returns a generator for the values of `recorder` at every chain.
+Returns a generator for the values of a recorder of type `OnlineStatsBase.GroupBy`.
 """
-recorder_values(pt::PT, recorder::Symbol) = 
-    (value(v) for v in values(value(pt.reduced_recorders[recorder])))
+recorder_values(pt::PT, recorder_name::Symbol) = 
+    recorder_values(pt.reduced_recorders, recorder_name::Symbol)
+recorder_values(reduced_recorders, recorder_name::Symbol) = 
+    recorder_values(reduced_recorders[recorder_name])
+recorder_values(recorder::GroupBy) = (value(v) for v in values(value(recorder)))
 
 """ 
 Average MH swap acceptance probabilities for each pairs 


### PR DESCRIPTION
Fix for #233 where I forgot to add the reversibility rate recorder to the report. I also improved the code and docstring for `recorder_values`.