### PR TITLE
Fix dispatch of ADgradient calls

### DIFF
--- a/ext/PigeonsBridgeStanExt/interface.jl
+++ b/ext/PigeonsBridgeStanExt/interface.jl
@@ -54,7 +54,7 @@ Evaluate the log potential at a given point `x` of type `Pigeons.StanState`.
 (log_potential::StanLogPotential)(state::Pigeons.StanState) =
     LogDensityProblems.logdensity(log_potential, state.unconstrained_parameters)
 
-LogDensityProblemsAD.ADgradient(kind, log_potential::StanLogPotential, buffers::Pigeons.Augmentation) =
+LogDensityProblemsAD.ADgradient(kind::Val, log_potential::StanLogPotential, buffers::Pigeons.Augmentation) =
     Pigeons.BufferedAD(log_potential, buffers, Ref(0.0), Ref{Cstring}())
 
 LogDensityProblems.logdensity(log_potential::Pigeons.BufferedAD{StanLogPotential{M, S, D, E}}, x) where {M, S, D, E} =

--- a/ext/PigeonsDynamicPPLExt/interface.jl
+++ b/ext/PigeonsDynamicPPLExt/interface.jl
@@ -97,7 +97,7 @@ LogDensityProblems.dimension(log_potential::TuringLogPotential) = log_potential.
 
 # ADgradient
 # general case
-LogDensityProblemsAD.ADgradient(kind, log_potential::TuringLogPotential, replica::Pigeons.Replica) =
+LogDensityProblemsAD.ADgradient(kind::Val, log_potential::TuringLogPotential, replica::Pigeons.Replica) =
     ADgradient(
         kind, 
         DynamicPPL.LogDensityFunction(replica.state, log_potential.model, log_potential.context), 

--- a/src/Pigeons.jl
+++ b/src/Pigeons.jl
@@ -15,6 +15,7 @@ using Dates
 using Distributions
 using DocStringExtensions
 using Expect
+using FillArrays
 using Graphs
 using Interpolations
 using JSON

--- a/src/explorers/BufferedAD.jl
+++ b/src/explorers/BufferedAD.jl
@@ -28,10 +28,15 @@ BufferedAD(log_potential, buffers::Augmentation, logd_buffer = nothing, err_buff
         err_buffer 
 )
 
+# translate Symbol to Val
+# TODO: should we move to ADTypes?
+LogDensityProblemsAD.ADgradient(kind::Symbol, log_potential, replica::Replica; kwargs...) = 
+    ADgradient(Val{kind}(), log_potential, replica; kwargs...)
+
 # default implementation of the ADgradient interface
-LogDensityProblemsAD.ADgradient(kind, log_potential, replica::Replica; kwargs...) =
+LogDensityProblemsAD.ADgradient(kind::Val, log_potential, replica::Replica; kwargs...) =
     ADgradient(kind, log_potential, replica.recorders.buffers; kwargs...)
-LogDensityProblemsAD.ADgradient(kind, log_potential, buffers::Augmentation; kwargs...) =
+LogDensityProblemsAD.ADgradient(kind::Val, log_potential, buffers::Augmentation; kwargs...) =
     Pigeons.BufferedAD(ADgradient(kind, log_potential; kwargs...), buffers)
 
 # default case does not use the buffer
@@ -69,7 +74,7 @@ $FIELDS
 end
 
 function LogDensityProblemsAD.ADgradient(
-    kind,
+    kind::Val,
     log_potential::InterpolatedLogPotential{<:InterpolatingPath{<:Any,<:Any,LinearInterpolator}},
     replica::Replica
     )

--- a/src/paths/ScaledPrecisionNormalPath.jl
+++ b/src/paths/ScaledPrecisionNormalPath.jl
@@ -24,7 +24,7 @@ end
 LogDensityProblems.logdensity(log_potential::ScaledPrecisionNormalLogPotential, x) = log_potential(x)
 LogDensityProblems.dimension(log_potential::ScaledPrecisionNormalLogPotential) = log_potential.dim
 
-LogDensityProblemsAD.ADgradient(kind, log_potential::ScaledPrecisionNormalLogPotential, buffers::Augmentation) =
+LogDensityProblemsAD.ADgradient(kind::Val, log_potential::ScaledPrecisionNormalLogPotential, buffers::Augmentation) =
     BufferedAD(log_potential, buffers)
 
 function LogDensityProblems.logdensity_and_gradient(log_potential::BufferedAD{ScaledPrecisionNormalLogPotential}, x)

--- a/src/targets/DistributionLogPotential.jl
+++ b/src/targets/DistributionLogPotential.jl
@@ -41,8 +41,11 @@ LogDensityProblems.dimension(log_potential::DistributionLogPotential) = length(l
 LogDensityProblems.dimension(::DistributionLogPotential{<:UnivariateDistribution}) = 1
 
 # special ADgradient constructor for ForwardDiff
-LogDensityProblemsAD.ADgradient(
+function LogDensityProblemsAD.ADgradient(
     kind::Val{:ForwardDiff}, 
     log_potential::DistributionLogPotential, 
-    buffers::Augmentation) =
-    ADgradient(kind, fct, buffers; x=Zeros{eltype(log_potential.dist)}(length(log_potential.dist)))
+    buffers::Augmentation
+    )
+    x_template = Zeros{eltype(log_potential.dist)}(length(log_potential.dist))
+    ADgradient(kind, log_potential, buffers; x=x_template)
+end

--- a/src/variational/GaussianReference.jl
+++ b/src/variational/GaussianReference.jl
@@ -62,7 +62,7 @@ function LogDensityProblems.dimension(log_potential::GaussianReference)
     return length(log_potential.mean[:singleton_variable])
 end
 
-LogDensityProblemsAD.ADgradient(kind, log_potential::GaussianReference, buffers::Augmentation) = 
+LogDensityProblemsAD.ADgradient(kind::Val, log_potential::GaussianReference, buffers::Augmentation) = 
     BufferedAD(log_potential, buffers)
 
 function LogDensityProblems.logdensity_and_gradient(log_potential::BufferedAD{GaussianReference}, x)


### PR DESCRIPTION
Resolve ambiguity in ADgradient calls by forcing all methods to only take Val arguments, except for a catch-all converter from Symbol to Val.

It will be easy then if we want to move to [ADTypes](https://github.com/SciML/ADTypes.jl/); simply replace the Val arg restriction with ADType.