### PR TITLE
Fix CI to a specific minor version of Julia

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -98,7 +98,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1'
+          - '1.10'
         os:
           - macos-13
         mpi:
@@ -153,7 +153,7 @@ jobs:
           java-version: '11'
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.9'
+          version: '1.10'
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-docdeploy@latest
         env:


### PR DESCRIPTION
Some brittle tests are failing in 1.11 as shown in #284 . For now this PR simply fixes the julia minor version across the CI. In fact,  everything was already fixed except for 1 family of macos tests.

I'm also using the opportunity to bump the version of julia used for the docs.