### PR TITLE
Remove GSOC from pages

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -73,8 +73,7 @@ InferenceReport.headless() do
             "Interfaces" => Pigeons.informal_doc(@__DIR__, Pigeons),
             "Reference" => "reference.md",
             "Openings" => "openings.md",
-            "About Us" => "about-us.md",
-            "Google Summer of Code" => "gsoc.md"
+            "About Us" => "about-us.md"
         ],
     )
 end


### PR DESCRIPTION
Hide GSOC projects to avoid confusion