### PR TITLE
Fix MPI serialization for JuliaBUGS extension

### DIFF
--- a/ext/PigeonsJuliaBUGSExt/PigeonsJuliaBUGSExt.jl
+++ b/ext/PigeonsJuliaBUGSExt/PigeonsJuliaBUGSExt.jl
@@ -8,6 +8,7 @@ if isdefined(Base, :get_extension)
     using DocStringExtensions
     using SplittableRandoms: SplittableRandom, split
     using Random
+    using Serialization
 else
     import ..JuliaBUGS
     using ..AbstractPPL # only need because we rewrite JuliaBUGS.getparams
@@ -15,6 +16,7 @@ else
     using ..DocStringExtensions
     using ..SplittableRandoms: SplittableRandom, split
     using ..Random
+    using ..Serialization
 end
 
 include(joinpath(@__DIR__, "utils.jl"))

--- a/src/paths/JuliaBUGSPath.jl
+++ b/src/paths/JuliaBUGSPath.jl
@@ -11,4 +11,19 @@ $FIELDS
     A `JuliaBUGS.BUGSModel`.
     """
     model
+
+    """
+    Model definition (for serialization).
+    """
+    model_def
+
+    """
+    Data (for serialization).
+    """
+    data
+end
+
+# Constructor that automatically extracts model_def and data from model
+function JuliaBUGSPath(model)
+    JuliaBUGSPath(model, model.model_def, Pigeons.Immutable(model.data))
 end


### PR DESCRIPTION
The JuliaBUGS.BUGSModel contains runtime-generated functions that cannot be serialized across MPI processes. This commit implements custom serialization following the same pattern used in the Stan extension:

- Modified JuliaBUGSPath to store model_def and data fields
- Added custom serialize/deserialize methods for JuliaBUGSPath
- Added custom serialize/deserialize methods for JuliaBUGSLogPotential
- Only serialize the information needed to reconstruct the model
- Reconstruct models on each MPI node during deserialization