### PR TITLE
Change note style from 'terminology' to 'tip'

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -102,7 +102,7 @@ known only up to a normalization constant,
 where ``\gamma`` can be evaluated pointwise, but ``Z`` is unknown.
 Pigeons takes as input the function ``\gamma``.
 
-!!! terminology `log_potential`
+!!! tip `log_potential`
 
     Since we work in log-scale, we use the terminology 
     `log_potential` as a shorthand for the 


### PR DESCRIPTION
`!!! terminology` is not a supported admonition from Documenter.jl - changing to `!!! tip`. Pulled from this page: https://documenter.juliadocs.org/stable/showcase/#Admonitions