### PR TITLE
Fix sample_names for DynamicPPL models with constrained parameters

### DIFF
--- a/ext/PigeonsDynamicPPLExt/state.jl
+++ b/ext/PigeonsDynamicPPLExt/state.jl
@@ -53,9 +53,9 @@ end
 
 function Pigeons.sample_names(state::DynamicPPL.VarInfo, _)
     result = Symbol[]
-    all_names = DynamicPPL.getsym.(keys(state))
-    for var_name in all_names
-        var = Pigeons.variable(state, var_name)
+    for vn in keys(state)
+        var_name = Symbol(vn)
+        var = getindex(state, vn)
         if var isa Number || (var isa AbstractArray && length(var) == 1)
             push!(result, var_name)
         elseif var isa AbstractArray

--- a/test/test_turing.jl
+++ b/test/test_turing.jl
@@ -36,3 +36,21 @@ end
     PigeonsDynamicPPLExt.flatten!(vi, dest)
     @test vi[:] == dest
 end
+
+@testset "Turing-variable-names-Dirichlet" begin
+    # For models with constrained distributions like Dirichlet, the unconstrained
+    # internal representation has fewer dimensions than the user-facing one
+    # (a length-K Dirichlet uses K-1 unconstrained dims due to the simplex constraint).
+    # sample_names must report the user-facing (constrained) names; previously
+    # it iterated over the unconstrained representation, dropping x[K] and y[K].
+    @model function dirichlet_sample_names_model()
+        x ~ Dirichlet([1.0, 2.0, 1.0])
+        y ~ Dirichlet([1.0, 2.0, 1.0])
+    end
+    pt = pigeons(target = TuringLogPotential(dirichlet_sample_names_model()), n_rounds = 2)
+    names = sample_names(pt)
+    @test length(names) == 6 + 1  # 3 components per Dirichlet × 2 vars + :log_density
+    @test Symbol("x[3]") in names
+    @test Symbol("y[3]") in names
+    @test :log_density in names
+end


### PR DESCRIPTION
## Summary

Fix a bug where `sample_names` returned fewer names than expected for DynamicPPL models with constrained distributions like `Dirichlet`.

## Problem

For a model with `x ~ Dirichlet([1.0, 2.0, 1.0])` and `y ~ Dirichlet([1.0, 2.0, 1.0])`, the user-facing representation has 6 components (`x[1], x[2], x[3], y[1], y[2], y[3]`), but the unconstrained internal representation has only 4 (one fewer per simplex, since `Dirichlet(K)` lives on a `(K-1)`-dimensional simplex). The previous implementation of `sample_names` iterated over `Pigeons.variable(state, var_name)`, which returns the unconstrained representation, so the last component of each Dirichlet variable was dropped.

Before fix:
[Symbol("x[1]"), Symbol("x[2]"), Symbol("y[1]"), Symbol("y[2]"), :log_density]

After fix:
[Symbol("x[1]"), Symbol("x[2]"), Symbol("x[3]"), Symbol("y[1]"), Symbol("y[2]"), Symbol("y[3]"), :log_density]

## Test

Added a regression test in `test/test_turing.jl` (`@testset "Turing-variable-names-Dirichlet"`) using a model with two `Dirichlet([1.0, 2.0, 1.0])` variables, asserting `length(sample_names(pt)) == 7` and the presence of `x[3]`, `y[3]`, and `:log_density`.