### PR TITLE
Add per-chain stepping stone log-evidence estimator

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -55,7 +55,8 @@ InferenceReport.headless() do
                 "PT diagnostics" => "output-pt.md",
                 "Custom types" => "output-custom-types.md",
                 "Extended output" => "output-extended.md",
-                "MPI output" => "output-mpi-postprocessing.md"
+                "MPI output" => "output-mpi-postprocessing.md",
+                "Log Ratio of Normalizing Constant Across the Tempering Ladder" => "logZ_per_chain.md"
             ],
             "Checkpoints" => "checkpoints.md",
             "Correctness checks" => "correctness.md",

--- a/docs/src/logZ_per_chain.md
+++ b/docs/src/logZ_per_chain.md
@@ -1,0 +1,120 @@
+```@meta
+CurrentModule = Pigeons
+```
+
+# [Log Ratio of Normalizing Constant Across the Tempering Ladder](@id logZ-per-chain-page)
+
+## Background
+
+The standard [`stepping_stone()`](@ref) estimator computes a single 
+number: ``\log(Z_1/Z_0)``, the log-ratio of the normalizing constants 
+of the target and reference. 
+
+However, the stepping stone estimator is built from a **telescoping product**:
+ 
+```math
+\log \frac{Z_1}{Z_0} = \sum_{k=0}^{K-1} \log \frac{Z_{\beta_{k+1}}}{Z_{\beta_k}}
+```
+ 
+where ``\beta_0 = 0, \beta_1, \ldots, \beta_K = 1`` is the temperature schedule.
+ 
+By computing *partial sums* of this telescoping decomposition, we can 
+estimate ``\log(Z_{\beta_k}/Z_0)`` for every distribution in the 
+tempering ladder, not just the final target.
+
+## Computing per-chain estimated log-ratio of the normalizing constants
+
+Use [`stepping_stone_per_chain()`](@ref) to obtain the estimated 
+``\log(Z_{\beta_k}/Z_0)`` at each temperature:
+
+```@example perchain
+using Pigeons
+using Plots
+plotlyjs()
+ 
+pt = pigeons(
+    target = toy_mvn_target(2), 
+    n_rounds = 10,
+    n_chains = 15)
+ 
+result = stepping_stone_per_chain(pt)
+nothing # hide
+```
+
+The returned `result` is a `NamedTuple` with two fields:
+ 
+- `result.betas`: the temperature schedule (from 0 to 1)
+- `result.log_norm_constants`: the cumulative ``\log(Z_{\beta_k}/Z_0)`` estimates
+```@example perchain
+result.betas
+```
+ 
+```@example perchain
+result.log_norm_constants
+```
+
+## Plotting
+ 
+The result can be plotted directly using the built-in `Plots.jl` recipe:
+ 
+```@example perchain
+myplot = plot(result)
+savefig(myplot, "logz_per_chain_plot.html"); 
+nothing # hide
+```
+ 
+```@raw html
+<iframe src="../logz_per_chain_plot.html" style="height:500px;width:100%;"></iframe>
+```
+
+## Validation against analytic results
+ 
+When both the target and reference are multivariate normals with 
+kernels ``\exp(-x^\top x / (2\sigma^2))``, the log-normalizing 
+constant ratio has a closed-form expression:
+ 
+```math
+\log \frac{Z_{\beta}}{Z_0} = -\frac{d}{2}\left[\log(\sigma_{\text{ref}}^2) + \log\left(\frac{\beta}{\sigma_{\text{target}}^2} + \frac{1-\beta}{\sigma_{\text{ref}}^2}\right)\right]
+```
+ 
+This can be used to verify the estimator:
+ 
+```@example perchain
+d = 5
+var_ref = 25.0
+var_target = 1.0
+ 
+struct LogMVN
+    var::Float64
+end
+ 
+(m::LogMVN)(x) = -(x' * x) / (2 * m.var)
+ 
+Pigeons.initialization(mvn::LogMVN, rng, dim) = randn(rng, d)
+ 
+pt_test = pigeons(
+    target = LogMVN(var_target),
+    reference = LogMVN(var_ref),
+    n_rounds = 10,
+    n_chains = 30)
+ 
+result_test = stepping_stone_per_chain(pt_test)
+ 
+analytic = [
+    -(d/2) * (log(var_ref) + log(β/var_target + (1-β)/var_ref)) 
+    for β in result_test.betas
+]
+ 
+myplot = plot(result_test.betas, result_test.log_norm_constants, 
+    label="Stepping stone", linewidth=2)
+plot!(result_test.betas, analytic, 
+    label="Analytic", linestyle=:dash, linewidth=2)
+xlabel!("β")
+ylabel!("log(Z_β / Z₀)")
+savefig(myplot, "logz_validation_plot.html"); 
+nothing # hide
+```
+ 
+```@raw html
+<iframe src="../logz_validation_plot.html" style="height:500px;width:100%;"></iframe>
+```

--- a/src/Pigeons.jl
+++ b/src/Pigeons.jl
@@ -67,7 +67,7 @@ export pigeons, Inputs, PT,
     Result, setup_mpi, queue_status, queue_ncpus_free, kill_job, watch,
     # load, <- removed to avoid clash - see https://github.com/Julia-Tempering/Pigeons.jl/issues/200
     # getting information out of an execution:
-    stepping_stone, n_tempered_restarts, n_round_trips, process_sample, get_sample,
+    stepping_stone, stepping_stone_per_chain, n_tempered_restarts, n_round_trips, process_sample, get_sample,
     # variational references:
     GaussianReference,
     # samplers

--- a/src/evidence/stepping_stone.jl
+++ b/src/evidence/stepping_stone.jl
@@ -63,3 +63,51 @@ function stepping_stone_keys(pt::PT, log_sum_ratios::GroupBy, ::StabilizedPT)
     end
     return result
 end
+
+"""
+$SIGNATURES
+
+Compute estimated ``\\log(Z_{\\beta_k}/Z_0)`` for each temperature ``\\beta_k`` 
+in the schedule, using the stepping stone estimator's telescoping decomposition.
+
+Returns a `NamedTuple` with fields:
+- `betas::Vector{Float64}` — the temperature schedule (0.0 to 1.0)
+- `log_norm_constants::Vector{Float64}` — cumulative ``\\log(Z_{\\beta_k}/Z_0)``
+"""
+function stepping_stone_per_chain(pt::PT)
+    return _stepping_stone_per_chain(pt, pt.shared.tempering)
+end
+
+function _stepping_stone_per_chain(pt::PT, tempering::NonReversiblePT)
+    betas = tempering.schedule.grids
+    K = length(betas)
+
+    log_sum_ratios = pt.reduced_recorders.log_sum_ratio
+
+    # Collect forward estimates: key(i, i+1)
+    # Collect backward estimates: key(i+1, i)
+    # Sandwich estimator: average forward and backward
+
+    forward = zeros(K) # forward[k] = estimate of log(Z_{β_k}/Z_{β_{k-1}}) from chain k-1 -> k
+    backward = zeros(K) # backward[k] = estimate of log(Z_{β_{k-1}}/Z_{β_{k}}) from chain k -> k-1
+
+    for (i, j) in keys(log_sum_ratios.value)
+        ls = log_sum_ratios[(i, j)]
+        est = value(ls) - log(ls.n)
+
+        if i < j && j <= K 
+            forward[j] = est 
+        elseif i > j && i <= K 
+            backward[i] = est 
+        end
+    end
+
+    # build cumulative sums 
+    log_norm_constants = zeros(K)
+    for k in 2:K
+        local_est = (forward[k] + (-backward[k])) / 2.0
+        log_norm_constants[k] = log_norm_constants[k-1] + local_est
+    end
+
+    return (betas = collect(betas), log_norm_constants = log_norm_constants)
+end

--- a/src/pt/plots.jl
+++ b/src/pt/plots.jl
@@ -36,4 +36,23 @@ plot(pt.shared.tempering.communication_barriers.localbarrier)
     return x, y
 end  
 
+"""
+```@example
+using Pigeons
+using Plots
+pt = pigeons(target = toy_mvn_target(1))
+result = stepping_stone_per_chain(pt)
+plot(result)
+```
+"""
+@recipe function plot_logz_per_chain(result::NamedTuple{(:betas, :log_norm_constants)})
+    xlabel --> "β"
+    ylabel --> "log(Z_β / Z₀)"
+    legend := false
+    markershape --> :circle
+    markersize --> 3
+    linewidth --> 2
+    return result.betas, result.log_norm_constants
+end
+
 

--- a/test/test_allocs.jl
+++ b/test/test_allocs.jl
@@ -15,14 +15,14 @@
     end
 end
 
-@testset "Allocs-SliceSampler" begin
-    allocs_10_rounds = Pigeons.last_round_max_allocation(pigeons(n_rounds = 11, target = toy_mvn_target(100)))
-    allocs_11_rounds = Pigeons.last_round_max_allocation(pigeons(n_rounds = 12, target = toy_mvn_target(100)))
-    @test allocs_10_rounds == allocs_11_rounds
-end
+# @testset "Allocs-SliceSampler" begin
+#     allocs_10_rounds = Pigeons.last_round_max_allocation(pigeons(n_rounds = 11, target = toy_mvn_target(100)))
+#     allocs_11_rounds = Pigeons.last_round_max_allocation(pigeons(n_rounds = 12, target = toy_mvn_target(100)))
+#     @test allocs_10_rounds == allocs_11_rounds
+# end
 
-@testset "Allocs-AutoMALA" begin
-    allocs_rounds = Pigeons.last_round_max_allocation(pigeons(n_rounds = 13, target = toy_mvn_target(1), explorer = AutoMALA()))
-    allocs_rounds_longer = Pigeons.last_round_max_allocation(pigeons(n_rounds = 14, target = toy_mvn_target(1), explorer = AutoMALA()))
-    @test allocs_rounds == allocs_rounds_longer
-end
+# @testset "Allocs-AutoMALA" begin
+#     allocs_rounds = Pigeons.last_round_max_allocation(pigeons(n_rounds = 13, target = toy_mvn_target(1), explorer = AutoMALA()))
+#     allocs_rounds_longer = Pigeons.last_round_max_allocation(pigeons(n_rounds = 14, target = toy_mvn_target(1), explorer = AutoMALA()))
+#     @test allocs_rounds == allocs_rounds_longer
+# end

--- a/test/test_allocs.jl
+++ b/test/test_allocs.jl
@@ -15,14 +15,14 @@
     end
 end
 
-# @testset "Allocs-SliceSampler" begin
-#     allocs_10_rounds = Pigeons.last_round_max_allocation(pigeons(n_rounds = 11, target = toy_mvn_target(100)))
-#     allocs_11_rounds = Pigeons.last_round_max_allocation(pigeons(n_rounds = 12, target = toy_mvn_target(100)))
-#     @test allocs_10_rounds == allocs_11_rounds
-# end
+@testset "Allocs-SliceSampler" begin
+    allocs_10_rounds = Pigeons.last_round_max_allocation(pigeons(n_rounds = 11, target = toy_mvn_target(100)))
+    allocs_11_rounds = Pigeons.last_round_max_allocation(pigeons(n_rounds = 12, target = toy_mvn_target(100)))
+    @test allocs_10_rounds == allocs_11_rounds
+end
 
-# @testset "Allocs-AutoMALA" begin
-#     allocs_rounds = Pigeons.last_round_max_allocation(pigeons(n_rounds = 13, target = toy_mvn_target(1), explorer = AutoMALA()))
-#     allocs_rounds_longer = Pigeons.last_round_max_allocation(pigeons(n_rounds = 14, target = toy_mvn_target(1), explorer = AutoMALA()))
-#     @test allocs_rounds == allocs_rounds_longer
-# end
+@testset "Allocs-AutoMALA" begin
+    allocs_rounds = Pigeons.last_round_max_allocation(pigeons(n_rounds = 13, target = toy_mvn_target(1), explorer = AutoMALA()))
+    allocs_rounds_longer = Pigeons.last_round_max_allocation(pigeons(n_rounds = 14, target = toy_mvn_target(1), explorer = AutoMALA()))
+    @test allocs_rounds == allocs_rounds_longer
+end

--- a/test/test_ss_per_chain.jl
+++ b/test/test_ss_per_chain.jl
@@ -1,0 +1,38 @@
+@testset "stepping_stone_per_chain matches analytic for MVN" begin
+    # For two centered MVNs with kernel exp(-x'x / 2σ²), the log-ratio of 
+    # normalizing constants along the geometric tempering path has a closed form:
+    #   log(Z_β/Z_0) = -(d/2) [log(σ²_ref) + log(β/σ²_target + (1-β)/σ²_ref)]
+    
+    d = 5
+    var_ref = 25.0
+    var_target = 1.0
+    
+    struct LogMVNTarget
+        var::Float64
+    end
+    (m::LogMVNTarget)(x::Vector{Float64}) = -(x' * x) / (2 * m.var)
+    Pigeons.initialization(mvn::LogMVNTarget, rng::AbstractRNG, _::Int) = randn(rng, d)
+    
+    pt = pigeons(
+        target = LogMVNTarget(var_target),
+        reference = LogMVNTarget(var_ref),
+        n_rounds = 10,
+        n_chains = 30
+    )
+    
+    result = stepping_stone_per_chain(pt)
+    analytic = [
+        -(d/2) * (log(var_ref) + log(β/var_target + (1-β)/var_ref))
+        for β in result.betas
+    ]
+    
+    # Sanity checks on structure
+    @test length(result.betas) == length(result.log_norm_constants)
+    @test result.betas[1] == 0.0
+    @test result.betas[end] == 1.0
+    @test result.log_norm_constants[1] == 0.0  # by construction
+    
+    for k in eachindex(result.betas)
+        @test isapprox(result.log_norm_constants[k], analytic[k], atol=0.5)
+    end
+end


### PR DESCRIPTION
## New Feature Summary

Add `stepping_stone_per_chain`, which estimates `log(Z_β_k / Z_0)` for every temperature in the parallel tempering schedule, in addition to the existing `stepping_stone` which only returns the final target/reference ratio.

## Change

- `src/evidence/stepping_stone.jl`: new functions `stepping_stone_per_chain` (user-facing) and `_stepping_stone_per_chain` (underlying function which needs tempering type as input). Currently implements the `NonReversiblePT` case via a sandwich estimator that averages forward and backward log-sum-ratios at each chain.
- `src/Pigeons.jl`: export `stepping_stone_per_chain`.
- `src/pt/plots.jl`: Plots.jl `@recipe` for the result `NamedTuple{(:betas, :log_norm_constants)}`, so `plot(stepping_stone_per_chain(pt))` works.
- `docs/src/logZ_per_chain.md`: new documentation page with theoretical background, usage example, and analytic validation against a Gaussian-vs-Gaussian benchmark with a closed-form answer.
- `docs/make.jl`: register the new doc page.

## Test

`test/test_ss_per_chain.jl` runs PT on a centered MVN target with a wider MVN reference, computes the per-chain log-Z estimates, and compares against the closed-form analytic answer for the geometric tempering path with tolerance of 0.5.

## Note:
Currently only the `NonReversiblePT` tempering case is implemented.