### PR TITLE
bump Comrade upperbound to 0.11.30

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -45,4 +45,4 @@ VLBIImagePriors = "b1ba175b-8447-452c-b961-7db2d6f7a029"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
-Comrade = "=0.11.25" # fix package version for now, should be removed when possible
+Comrade = "0.11.25, 0.11.30" # fix package version for now, should be removed when possible


### PR DESCRIPTION
bump Comrade version upperbound to 0.11.30 in test environment